### PR TITLE
Add Create Team Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateTeamCommand.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Creates a team with the input name.
+ */
+public class CreateTeamCommand extends Command {
+
+    public static final String COMMAND_WORD = "create_team";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a team with a name specified by the input.\n"
+            + "Parameters: NAME (must be a valid string) "
+            + "Example: " + COMMAND_WORD + " Team_1";
+
+    public static final String MESSAGE_CREATE_TEAM_SUCESS = "Created Team: %s";
+
+    private final String teamName;
+
+    /**
+     * @param teamName name of the team
+     */
+    public CreateTeamCommand(String teamName) {
+        requireAllNonNull(teamName);
+
+        this.teamName = teamName;
+    }
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+
+        return new CommandResult(generateSuccessMessage("hi"));
+    }
+
+    /**
+     * Generates a command execution success message with team name
+     */
+    private String generateSuccessMessage(String teamName) {
+        return String.format(MESSAGE_CREATE_TEAM_SUCESS, teamName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CreateTeamCommand)) {
+            return false;
+        }
+
+        // state check
+        CreateTeamCommand e = (CreateTeamCommand) other;
+        return teamName.equals(e.teamName);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CreateTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateTeamCommand.java
@@ -31,7 +31,7 @@ public class CreateTeamCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
 
-        return new CommandResult(generateSuccessMessage("hi"));
+        return new CommandResult(generateSuccessMessage(this.teamName));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CreateTeamCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case CreateTeamCommand.COMMAND_WORD:
+            return new CreateTeamCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
@@ -1,9 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.CreateTeamCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CreateTeamCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.CreateTeamCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code CreateTeamCommand} object
+ */
+public class CreateTeamCommandParser implements Parser<CreateTeamCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code CreateTeamCommand}
+     * and returns a {@code CreateTeamCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CreateTeamCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+
+        String teamName;
+        teamName = argMultimap.getPreamble();
+
+        return new CreateTeamCommand(teamName);
+    }
+}

--- a/src/main/java/seedu/address/model/ReadOnlyTeam.java
+++ b/src/main/java/seedu/address/model/ReadOnlyTeam.java
@@ -1,0 +1,17 @@
+package seedu.address.model;
+
+import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
+
+/**
+ * Unmodifiable view of a team
+ */
+public interface ReadOnlyTeam {
+
+    /**
+     * Returns an unmodifiable view of the persons list.
+     * This list will not contain any duplicate persons.
+     */
+    ObservableList<Person> getPersonList();
+
+}

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -97,6 +97,14 @@ public class UniquePersonList implements Iterable<Person> {
         internalList.setAll(persons);
     }
 
+
+    /**
+     * Returns the size of the {@code ObservableList}.
+     */
+    public int size() {
+        return internalList.size();
+    }
+
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */

--- a/src/main/java/seedu/address/model/team/Team.java
+++ b/src/main/java/seedu/address/model/team/Team.java
@@ -1,0 +1,171 @@
+package seedu.address.model.team;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.List;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.ReadOnlyTeam;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.UniquePersonList;
+import seedu.address.model.team.exceptions.TeamMaxCapacityException;
+
+/**
+ * Wraps all data at the team level
+ * Duplicates are not allowed (by .isSamePerson comparison)
+ */
+public class Team implements ReadOnlyTeam {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    private static final int MAX_CAPACITY = 5;
+
+    private final String name;
+    private final UniquePersonList persons;
+
+    /*
+     * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
+     * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
+     *
+     * Note that non-static init blocks are not recommended to use. There are other ways to avoid duplication
+     *   among constructors.
+     */
+    {
+        persons = new UniquePersonList();
+    }
+
+    /**
+     * Constructs a {@code Team}.
+     *
+     * @param name A valid name.
+     */
+    public Team(String name) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        this.name = name;
+    }
+
+    /**
+     * Creates an Team using the Persons in the {@code toBeCopied}
+     */
+    public Team(String name, ReadOnlyTeam toBeCopied) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        this.name = name;
+        resetData(toBeCopied);
+    }
+
+    //// list overwrite operations
+
+    /**
+     * Replaces the contents of the person list with {@code persons}.
+     * {@code persons} must not contain duplicate persons.
+     */
+    public void setPersons(List<Person> persons) {
+        if (persons.size() > MAX_CAPACITY) {
+            throw new TeamMaxCapacityException();
+        }
+        this.persons.setPersons(persons);
+    }
+
+    /**
+     * Resets the existing data of this {@code Team} with {@code newData}.
+     */
+    public void resetData(ReadOnlyTeam newData) {
+        requireNonNull(newData);
+
+        setPersons(newData.getPersonList());
+    }
+
+    //// person-level operations
+
+    /**
+     * Returns true if a person with the same identity as {@code person} exists in the team.
+     */
+    public boolean hasPerson(Person person) {
+        requireNonNull(person);
+        return persons.contains(person);
+    }
+
+    /**
+     * Adds a person to the team.
+     * The person must not already exist in the team.
+     */
+    public void addPerson(Person p) {
+        if (persons.size() + 1 > MAX_CAPACITY) {
+            throw new TeamMaxCapacityException();
+        }
+        persons.add(p);
+    }
+
+    /**
+     * Replaces the given person {@code target} in the list with {@code editedPerson}.
+     * {@code target} must exist in the team.
+     * The person identity of {@code editedPerson} must not be the same as another existing person in the team.
+     */
+    public void setPerson(Person target, Person editedPerson) {
+        requireNonNull(editedPerson);
+
+        persons.setPerson(target, editedPerson);
+    }
+
+    /**
+     * Removes {@code key} from this {@code Team}.
+     * {@code key} must exist in the team.
+     */
+    public void removePerson(Person key) {
+        persons.remove(key);
+    }
+
+    public String getName() {
+        return name;
+    }
+    //// util methods
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("name", name)
+                .add("persons", persons)
+                .toString();
+    }
+
+    @Override
+    public ObservableList<Person> getPersonList() {
+        return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Team)) {
+            return false;
+        }
+
+        Team otherTeam = (Team) other;
+        return persons.equals(otherTeam.persons);
+    }
+
+    @Override
+    public int hashCode() {
+        return persons.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/team/exceptions/DuplicatePersonException.java
+++ b/src/main/java/seedu/address/model/team/exceptions/DuplicatePersonException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.team.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
+ * identity).
+ */
+public class DuplicatePersonException extends RuntimeException {
+    public DuplicatePersonException() {
+        super("Operation would result in duplicate persons");
+    }
+}

--- a/src/main/java/seedu/address/model/team/exceptions/PersonNotFoundException.java
+++ b/src/main/java/seedu/address/model/team/exceptions/PersonNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.team.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified person.
+ */
+public class PersonNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/team/exceptions/TeamMaxCapacityException.java
+++ b/src/main/java/seedu/address/model/team/exceptions/TeamMaxCapacityException.java
@@ -1,0 +1,12 @@
+package seedu.address.model.team.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
+ * identity).
+ */
+public class TeamMaxCapacityException extends RuntimeException {
+    public TeamMaxCapacityException() {
+        super("Operation would exceed team capacity");
+    }
+}
+


### PR DESCRIPTION
Fixes #51 
# Summary
- Added Team and relevant helper / exception classes
  - Similar logic to AddressBook, but with an additional `MAX_CAPACITY` field
- Added `create_team TEAMNAME` command

# Changes to note
- Added `size()` method to `UniquePersonList` for size comparison in `Team`

# Not included
- Addition of `team` field in `Person`