### PR TITLE
Wipes original storage file after saving corrupted backup

### DIFF
--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -62,12 +62,12 @@ public class StorageManager implements Storage {
         }
 
         try {
-                ReadOnlyAddressBook empty = new AddressBook();
-                addressBookStorage.saveAddressBook(empty, corruptedFile);
-                logger.info("Replaced corrupted data file with empty data file at: " + corruptedFile);
-            } catch (IOException ioe) {
-                logger.severe("Failed to recreate empty data file at " + corruptedFile + ": " + ioe.getMessage());
-            }
+            ReadOnlyAddressBook empty = new AddressBook();
+            addressBookStorage.saveAddressBook(empty, corruptedFile);
+            logger.info("Replaced corrupted data file with empty data file at: " + corruptedFile);
+        } catch (IOException ioe) {
+            logger.severe("Failed to recreate empty data file at " + corruptedFile + ": " + ioe.getMessage());
+        }
     }
 
     // ================ UserPrefs methods ==============================


### PR DESCRIPTION
Fixes #234 

After copying over the corrupted data, the original storage file would be wipes and replaced with an empty data file.